### PR TITLE
No-admin parameter

### DIFF
--- a/App/CygwinPortable/cygwinConfig.bat
+++ b/App/CygwinPortable/cygwinConfig.bat
@@ -12,5 +12,5 @@ rem USBDRV will be something like E:
 SET CYGROOT=%cd%
 SET USBDRV=%~d0
 
-start %CYGROOT%\cygwinConfig.exe -R %CYGROOT% -l %CYGROOT%\packages -K http://cygwinports.org/ports.gpg -n
+start %CYGROOT%\cygwinConfig.exe -B -R %CYGROOT% -l %CYGROOT%\packages -K http://cygwinports.org/ports.gpg -n
 rem cd App\CygwinPortable


### PR DESCRIPTION
setup*.exe needs -B or --no-admin to not check admin access. See https://www.cygwin.com/faq.html (Part 2.3)
